### PR TITLE
1.20.1 Implementation of Block Ingredients and addition of flower block input to BeeProduce recipes.

### DIFF
--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/BeeProduceRecipeCategory.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/BeeProduceRecipeCategory.java
@@ -1,7 +1,14 @@
 package com.accbdd.complicated_bees.compat.jei;
 
+import com.accbdd.complicated_bees.ComplicatedBees;
+import com.accbdd.complicated_bees.bees.Flower;
+import com.accbdd.complicated_bees.bees.GeneticHelper;
 import com.accbdd.complicated_bees.bees.Product;
 import com.accbdd.complicated_bees.bees.Species;
+import com.accbdd.complicated_bees.bees.gene.GeneFlower;
+import com.accbdd.complicated_bees.compat.jei.ingredient.ComplicatedIngredients;
+import com.accbdd.complicated_bees.datagen.builtin.Flowers;
+import com.accbdd.complicated_bees.registry.FlowerRegistration;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
@@ -9,11 +16,23 @@ import mezz.jei.api.recipe.IFocusGroup;
 import mezz.jei.api.recipe.RecipeIngredientRole;
 import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.crafting.Ingredient;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.server.ServerLifecycleHooks;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import static com.accbdd.complicated_bees.ComplicatedBees.LOGGER;
 import static com.accbdd.complicated_bees.ComplicatedBees.MODID;
 
 public class BeeProduceRecipeCategory implements IRecipeCategory<Species> {
@@ -52,6 +71,10 @@ public class BeeProduceRecipeCategory implements IRecipeCategory<Species> {
                 .setSlotName("input_species")
                 .addIngredients(VanillaTypes.ITEM_STACK, species.toMembers());
 
+        builder.addSlot(RecipeIngredientRole.INPUT, 14, 45)
+                .setSlotName("flower")
+                .addIngredients(ComplicatedIngredients.BLOCK, getFlowers(species));
+
         List<Product> products = species.getProducts();
         List<Product> specProducts = species.getSpecialtyProducts();
 
@@ -68,5 +91,40 @@ public class BeeProduceRecipeCategory implements IRecipeCategory<Species> {
                     .addIngredient(VanillaTypes.ITEM_STACK, specProducts.get(i).getStack())
                     .addRichTooltipCallback(new ChanceTooltipCallback(specProducts.get(i).getChance()));
         }
+    }
+
+    List<Block> getFlowers(Species species) {
+        Level level =Minecraft.getInstance().level;
+        if (null != level) {
+            Flower flower = level.registryAccess().registry(FlowerRegistration.FLOWER_REGISTRY_KEY).get()
+                    .get(((GeneFlower) GeneticHelper.getGene(species.toMembers().get(0), GeneFlower.ID, true)).get());
+            if (null != flower) {
+                ArrayList<Block> flowers = new ArrayList<>();
+                flower.getBlocksAsResourceLocs().stream().map(
+                   rl -> level.registryAccess().registry(Registries.BLOCK).orElseThrow().get(rl)
+                ).filter(Objects::nonNull).forEach(flowers::add);
+
+                flower.getTags().forEach(
+                       key -> {
+                           level.registryAccess().registry(Registries.BLOCK).orElseThrow().stream().filter(
+                                   block -> block.defaultBlockState().is(key)
+                           )
+                       .forEach(flowers::add);
+                       }
+                );
+
+                if (!flowers.isEmpty()) {
+
+                    return flowers;
+                }
+            }
+        }
+
+        LOGGER.error("No valid flower found for: {} \n" +
+                "This is an error from the {} JEI plugin and might not affect gameplay.",
+                species.toMembers().get(0).getDisplayName().getString(),
+                MODID);
+
+        return List.of();
     }
 }

--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/BeeProduceRecipeCategory.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/BeeProduceRecipeCategory.java
@@ -1,13 +1,11 @@
 package com.accbdd.complicated_bees.compat.jei;
 
-import com.accbdd.complicated_bees.ComplicatedBees;
 import com.accbdd.complicated_bees.bees.Flower;
 import com.accbdd.complicated_bees.bees.GeneticHelper;
 import com.accbdd.complicated_bees.bees.Product;
 import com.accbdd.complicated_bees.bees.Species;
 import com.accbdd.complicated_bees.bees.gene.GeneFlower;
 import com.accbdd.complicated_bees.compat.jei.ingredient.ComplicatedIngredients;
-import com.accbdd.complicated_bees.datagen.builtin.Flowers;
 import com.accbdd.complicated_bees.registry.FlowerRegistration;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
@@ -18,15 +16,10 @@ import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.nbt.Tag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.server.ServerLifecycleHooks;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/ComplicatedBeesJEI.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/ComplicatedBeesJEI.java
@@ -4,6 +4,10 @@ import com.accbdd.complicated_bees.bees.Comb;
 import com.accbdd.complicated_bees.bees.GeneticHelper;
 import com.accbdd.complicated_bees.bees.Species;
 import com.accbdd.complicated_bees.bees.gene.GeneSpecies;
+import com.accbdd.complicated_bees.compat.jei.ingredient.BlockRenderer;
+import com.accbdd.complicated_bees.compat.jei.ingredient.ComplicatedIngredients;
+import com.accbdd.complicated_bees.compat.jei.ingredient.BlockHelper;
+import com.accbdd.complicated_bees.compat.jei.ingredient.BlockListFactory;
 import com.accbdd.complicated_bees.item.CombItem;
 import com.accbdd.complicated_bees.registry.EsotericRegistration;
 import com.accbdd.complicated_bees.registry.ItemsRegistration;
@@ -101,6 +105,18 @@ public class ComplicatedBeesJEI implements IModPlugin {
     @Override
     public void registerGuiHandlers(IGuiHandlerRegistration registration) {
         registration.addGhostIngredientHandler(BeeSorterScreen.class, new BeeSorterDragDropJEI());
+    }
+
+    /**
+     * Register special ingredients, beyond the basic ItemStack and FluidStack.
+     *
+     * @param registration
+     */
+    @Override public void registerIngredients(IModIngredientRegistration registration) {
+        BlockHelper helper = new BlockHelper();
+
+        registration.register(ComplicatedIngredients.BLOCK, BlockListFactory.create(helper), helper, new BlockRenderer());
+        IModPlugin.super.registerIngredients(registration);
     }
 
     public static IDrawable createDrawable(ResourceLocation location, int uOffset, int vOffset, int width, int height, int textureWidth, int textureHeight) {

--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockHelper.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockHelper.java
@@ -1,5 +1,6 @@
 package com.accbdd.complicated_bees.compat.jei.ingredient;
 
+import mezz.jei.api.constants.Tags;
 import mezz.jei.api.ingredients.IIngredientHelper;
 import mezz.jei.api.ingredients.IIngredientType;
 import mezz.jei.api.ingredients.subtypes.UidContext;
@@ -45,7 +46,7 @@ public class BlockHelper implements IIngredientHelper<Block> {
     @Override
     public String getUniqueId(Block ingredient, UidContext context) {
 
-        return getRegistryNameForBlock(ingredient);
+        return "Block: " + getRegistryNameForBlock(ingredient);
     }
 
     private String getRegistryNameForBlock(Block ingredient) {
@@ -108,6 +109,8 @@ public class BlockHelper implements IIngredientHelper<Block> {
      */
     @Override
     public ItemStack getCheatItemStack(Block block) {
+        // This try catch probably isn't necessary, and both paths should spit out an air stack (effectively nothing)
+        // if the BlockItem doesn't exist.
         try {
             return new ItemStack(block.asItem());
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockHelper.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockHelper.java
@@ -1,0 +1,131 @@
+package com.accbdd.complicated_bees.compat.jei.ingredient;
+
+import mezz.jei.api.ingredients.IIngredientHelper;
+import mezz.jei.api.ingredients.IIngredientType;
+import mezz.jei.api.ingredients.subtypes.UidContext;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+import static com.accbdd.complicated_bees.ComplicatedBees.MODID;
+
+@MethodsReturnNonnullByDefault @ParametersAreNonnullByDefault
+public class BlockHelper implements IIngredientHelper<Block> {
+
+    /**
+     * @return The ingredient type for this {@link IIngredientHelper}.
+     */
+    @Override
+    public IIngredientType<Block> getIngredientType() {
+        return ComplicatedIngredients.BLOCK;
+    }
+
+    /**
+     * Display name used for searching. Normally this is the first line of the tooltip.
+     *
+     * @param ingredient
+     */
+    @Override
+    public String getDisplayName(Block ingredient) {
+        return "Block: " + ingredient.getName().getString();
+    }
+
+    /**
+     * Unique ID for use in comparing, blacklisting, and looking up ingredients.
+     *
+     * @param ingredient
+     * @param context
+     * @since 7.3.0
+     */
+    @Override
+    public String getUniqueId(Block ingredient, UidContext context) {
+
+        return getRegistryNameForBlock(ingredient);
+    }
+
+    private String getRegistryNameForBlock(Block ingredient) {
+        ResourceLocation rl = ForgeRegistries.BLOCKS.getKey(ingredient);
+        if (null == rl) {
+            throw new NullPointerException("Blocks must be registered before being used as ingredients.");
+        }
+        return rl.toString();
+    }
+
+    /**
+     * Return the registry name of the given ingredient.
+     *
+     * @param ingredient
+     * @since 9.2.2
+     */
+    @Override
+    public ResourceLocation getResourceLocation(Block ingredient) {
+        return new ResourceLocation(getRegistryNameForBlock(ingredient));
+    }
+
+    /**
+     * Makes a copy of the given ingredient.
+     * Used by JEI to protect against mutation of ingredients.
+     *
+     * @param ingredient the ingredient to copy
+     * @return a copy of the ingredient
+     */
+    @Override
+    public Block copyIngredient(Block ingredient) {
+        // Blocks are singletons, so the only way to copy this would be to create
+        // an unregistered copy, and creating unregistered blocks is generally a bad idea.
+        // Let's hope there are no mutations.
+        return ingredient;
+    }
+
+
+
+    /**
+     * Get information for error messages involving this ingredient.
+     * Be extremely careful not to crash here, get as much useful info as possible.
+     *
+     * @param block
+     */
+    @Override
+    public String getErrorInfo(@Nullable Block block) {
+        if (null == block) {
+
+            return "Block ingredient is null";
+        }
+
+        return MODID + " registered an ingredient for the block " + getDisplayName(block) + ", registered at " + getRegistryNameForBlock(block) + " that has caused an error.";
+    }
+
+    /**
+     * Called when a player is in cheat mode and clicks an ingredient in the list.
+     *
+     * @param block The ingredient to cheat in. Do not edit this ingredient.
+     * @return an ItemStack for JEI to give the player, or an empty stack if there is nothing that can be given.
+     */
+    @Override
+    public ItemStack getCheatItemStack(Block block) {
+        try {
+            return new ItemStack(block.asItem());
+        } catch (IllegalArgumentException e) {
+            return ItemStack.EMPTY;
+        }
+    }
+
+    /**
+     * Return true if the given ingredient is hidden from recipe viewers by its tags.
+     *
+     * @param ingredient
+     * @see Tags#HIDDEN_FROM_RECIPE_VIEWERS
+     * @since 15.6.0
+     */
+    @Override
+    public boolean isHiddenFromRecipeViewersByTags(Block ingredient) {
+        // While showing blocktags is a useful utility, it's kind of wierd to have every block show up twice
+        // in JEI. Better to hide these from the search panel. Can be turned into a config option if desired.
+        return true;
+    }
+}

--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockListFactory.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockListFactory.java
@@ -1,0 +1,102 @@
+package com.accbdd.complicated_bees.compat.jei.ingredient;
+
+import mezz.jei.api.ingredients.subtypes.UidContext;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.server.Services;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.flag.FeatureFlagSet;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.CreativeModeTabs;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.ForgeRegistries;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public final class BlockListFactory {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public static List<Block> create(BlockHelper blockHelper) {
+
+        final List<Block> blockList = new ArrayList<>();
+        final Set<Object> blockUidSet = new HashSet<>();
+
+//        Minecraft minecraft = Minecraft.getInstance();
+//
+//        ClientLevel level = minecraft.level;
+//        if (level == null) {
+//            throw new NullPointerException("minecraft.level must be set before JEI fetches ingredients");
+//        }
+//        RegistryAccess registryAccess = level.registryAccess();
+
+
+        addItemsFromRegistries(blockHelper, blockList, blockUidSet);
+
+
+        return blockList;
+    }
+
+    private static void addItemsFromRegistries(
+            BlockHelper blockHelper,
+            List<Block> blockList,
+            Set<Object> blockUidSet
+    ) {
+        {
+            List<Block> blocks = ForgeRegistries.BLOCKS.getValues().stream().toList();
+
+            int added = 0;
+            for (Block block : blocks) {
+                Object blockKey = safeGetUid(blockHelper, block);
+                if (blockKey != null && blockUidSet.add(blockKey)) {
+                    blockList.add(block);
+                    added++;
+                }
+            }
+
+            LOGGER.debug(
+                    "Added {}/{} new items from the item registry (this is run because ShowHiddenItems is set to true in JEI's config)",
+                    added,
+                    blocks.size()
+            );
+        }
+
+        {
+            List<Block> blocks = ForgeRegistries.BLOCKS.getValues().stream().toList();
+
+            int added = 0;
+            for (Block block : blocks) {
+                String blockKey = safeGetUid(blockHelper, block);
+                if (blockKey != null && blockUidSet.add(blockKey)) {
+                    blockList.add(block);
+                    added++;
+                }
+            }
+
+            LOGGER.debug(
+                    "Added {}/{} new blocks from the block registry.",
+                    added,
+                    blocks.size()
+            );
+        }
+    }
+
+    @Nullable
+    private static String safeGetUid(BlockHelper blockHelper, Block block) {
+        return blockHelper.getUniqueId(block, UidContext.Ingredient);
+    }
+}

--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockRenderer.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockRenderer.java
@@ -1,0 +1,106 @@
+package com.accbdd.complicated_bees.compat.jei.ingredient;
+
+import mezz.jei.api.ingredients.IIngredientRenderer;
+import net.minecraft.MethodsReturnNonnullByDefault;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
+import net.minecraft.client.renderer.block.ModelBlockRenderer;
+import net.minecraft.client.renderer.block.model.BlockModel;
+import net.minecraft.client.renderer.entity.DisplayRenderer;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+
+import static com.accbdd.complicated_bees.ComplicatedBees.LOGGER;
+
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.models.blockstates.BlockStateGenerator;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.Services;
+import net.minecraft.world.entity.Display;
+import net.minecraft.world.entity.Pose;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.client.model.data.ModelDataManager;
+import net.minecraftforge.client.model.generators.BlockModelProvider;
+import net.minecraftforge.client.model.generators.BlockStateProvider;
+import org.slf4j.Logger;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+
+@MethodsReturnNonnullByDefault @ParametersAreNonnullByDefault
+public class BlockRenderer implements IIngredientRenderer<Block> {
+    /**
+     * Renders an ingredient.
+     *
+     * @param guiGraphics The current {@link GuiGraphics} for rendering the ingredient.
+     * @param ingredient  the ingredient to render.
+     * @since 9.3.0
+     */
+    @Override
+    public void render(GuiGraphics guiGraphics, Block ingredient) {
+        drawBlock(guiGraphics, ingredient);
+    }
+
+    private void drawBlock(GuiGraphics guiGraphics, Block block) {
+        try {
+            ItemStack blockItemStack = new ItemStack(block.asItem());
+            if (!blockItemStack.is(Items.AIR)) {
+                guiGraphics.renderFakeItem(new ItemStack(block.asItem()), 0, 0);
+            } else {
+                // Handle blocks without corresponding BlockItems
+//                BlockModel
+//                new BlockRenderDispatcher()
+//                ModelBlockRenderer renderer = new ModelBlockRenderer(BlockColors.createDefault());
+//                renderer.renderModel(Pose.CROAKING, );
+//                new BlockRenderDispatcher().getBlockModel(block.defaultBlockState()).getQuads().get(0).getSprite();
+                ModelManager manager = Minecraft.getInstance().getModelManager();
+                Level level = Minecraft.getInstance().level;
+                if (null != level) {
+                    ResourceLocation rl = level.registryAccess().registry(Registries.BLOCK).orElseThrow().getKey(block);
+                    if (null != rl) {
+                        TextureAtlasSprite sprite = manager.getModel(rl).getQuads(block.defaultBlockState(), Direction.NORTH, level.random).get(0).getSprite();
+                        guiGraphics.blit(0, 0, 0, 16, 16, sprite);
+                    } else {
+                        LOGGER.debug("Error parsing block: {} for JEI plugin.", block.getName().getString());
+                    }
+                }
+//                BlockRendererDispatcher.getModelForState(block.defaultBlockState()).getQuads.get.getSprite()
+//                BlockModelProvider.
+//                 block.defaultBlockState()
+            }
+        } catch (IllegalArgumentException e) {
+            LOGGER.error("Block [{}] handled badly and may not render properly in recipe viewers.",
+                    block.getName().getString());
+        }
+
+    }
+
+    /**
+     * Get the tooltip text for this ingredient. JEI renders the tooltip based on this.
+     *
+     * @param ingredient  The ingredient to get the tooltip for.
+     * @param tooltipFlag Whether to show advanced information on item tooltips, toggled by F3+H
+     * @return The tooltip text for the ingredient.
+     * @deprecated use {@link #getTooltip(ITooltipBuilder, Object, TooltipFlag)}
+     */
+    @Override
+    public List<Component> getTooltip(Block ingredient, TooltipFlag tooltipFlag) {
+        return List.of(ingredient.getName());
+    }
+
+
+}

--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockRenderer.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/BlockRenderer.java
@@ -1,45 +1,27 @@
 package com.accbdd.complicated_bees.compat.jei.ingredient;
 
+import mezz.jei.api.gui.builder.ITooltipBuilder;
 import mezz.jei.api.ingredients.IIngredientRenderer;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.color.block.BlockColors;
-import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.renderer.block.BlockRenderDispatcher;
-import net.minecraft.client.renderer.block.ModelBlockRenderer;
-import net.minecraft.client.renderer.block.model.BlockModel;
-import net.minecraft.client.renderer.entity.DisplayRenderer;
-import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
-import net.minecraft.client.resources.model.BakedModel;
 import net.minecraft.client.resources.model.ModelManager;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-
-import static com.accbdd.complicated_bees.ComplicatedBees.LOGGER;
-
 import net.minecraft.core.registries.Registries;
-import net.minecraft.data.models.blockstates.BlockStateGenerator;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.Services;
-import net.minecraft.world.entity.Display;
-import net.minecraft.world.entity.Pose;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.client.model.data.ModelDataManager;
-import net.minecraftforge.client.model.generators.BlockModelProvider;
-import net.minecraftforge.client.model.generators.BlockStateProvider;
-import org.slf4j.Logger;
+import net.minecraftforge.client.model.data.ModelData;
+import org.spongepowered.asm.mixin.injection.invoke.arg.ArgumentIndexOutOfBoundsException;
 
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
+
+import static com.accbdd.complicated_bees.ComplicatedBees.LOGGER;
 
 @MethodsReturnNonnullByDefault @ParametersAreNonnullByDefault
 public class BlockRenderer implements IIngredientRenderer<Block> {
@@ -62,29 +44,22 @@ public class BlockRenderer implements IIngredientRenderer<Block> {
                 guiGraphics.renderFakeItem(new ItemStack(block.asItem()), 0, 0);
             } else {
                 // Handle blocks without corresponding BlockItems
-//                BlockModel
-//                new BlockRenderDispatcher()
-//                ModelBlockRenderer renderer = new ModelBlockRenderer(BlockColors.createDefault());
-//                renderer.renderModel(Pose.CROAKING, );
-//                new BlockRenderDispatcher().getBlockModel(block.defaultBlockState()).getQuads().get(0).getSprite();
                 ModelManager manager = Minecraft.getInstance().getModelManager();
                 Level level = Minecraft.getInstance().level;
                 if (null != level) {
                     ResourceLocation rl = level.registryAccess().registry(Registries.BLOCK).orElseThrow().getKey(block);
                     if (null != rl) {
-                        TextureAtlasSprite sprite = manager.getModel(rl).getQuads(block.defaultBlockState(), Direction.NORTH, level.random).get(0).getSprite();
+                        TextureAtlasSprite sprite = manager.getBlockModelShaper().getBlockModel(block.defaultBlockState()).getParticleIcon(ModelData.EMPTY);
                         guiGraphics.blit(0, 0, 0, 16, 16, sprite);
                     } else {
                         LOGGER.debug("Error parsing block: {} for JEI plugin.", block.getName().getString());
                     }
                 }
-//                BlockRendererDispatcher.getModelForState(block.defaultBlockState()).getQuads.get.getSprite()
-//                BlockModelProvider.
-//                 block.defaultBlockState()
             }
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | ArgumentIndexOutOfBoundsException e) {
             LOGGER.error("Block [{}] handled badly and may not render properly in recipe viewers.",
                     block.getName().getString());
+            e.printStackTrace();
         }
 
     }
@@ -101,6 +76,4 @@ public class BlockRenderer implements IIngredientRenderer<Block> {
     public List<Component> getTooltip(Block ingredient, TooltipFlag tooltipFlag) {
         return List.of(ingredient.getName());
     }
-
-
 }

--- a/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/ComplicatedIngredients.java
+++ b/src/main/java/com/accbdd/complicated_bees/compat/jei/ingredient/ComplicatedIngredients.java
@@ -1,0 +1,23 @@
+package com.accbdd.complicated_bees.compat.jei.ingredient;
+
+import mezz.jei.api.ingredients.IIngredientType;
+import net.minecraft.world.level.block.Block;
+
+public class ComplicatedIngredients {
+
+    public static final IIngredientType<Block> BLOCK = new IIngredientType<>() {
+        @Override
+        public String getUid() {
+            return "block";
+        }
+
+        @Override
+        public Class<? extends Block> getIngredientClass() {
+            return Block.class;
+        }
+    };
+
+    private ComplicatedIngredients() {
+
+    }
+}


### PR DESCRIPTION
Requested in https://github.com/ACCBDD/complicated_bees/issues/59. Will add post there with some additional comments/questions.

A first pass at "properly" implementing flowers in JEI. As requested, I made a point of adding support for flowers without item equivalents. TintHandlers aren't supported, so a few images are greyscale (attached stems, for example). Probably doesn't support block entity renderers, but should still provide a tooltip/searchable ingredient. I don't expect crashes, but I wasn't able to get your test server working (it breaks third party mixins).

I haven't worried overly-much about optimizing the code, but noticed no problems when I chucked this into reclamation (and disabled EMI).

May need to be refactored to meet your style standards. I didn't look at much of your code before writing mine.