### PR TITLE
fix(gyrofuge): prevent NoSuchElementException crash

### DIFF
--- a/src/main/java/com/accbdd/complicated_bees/screen/GyrofugeMenu.java
+++ b/src/main/java/com/accbdd/complicated_bees/screen/GyrofugeMenu.java
@@ -53,7 +53,9 @@ public class GyrofugeMenu extends AbstractBaseInventoryMenu {
             addDataSlot(new DataSlot() {
                 @Override
                 public int get() {
-                    return controller.getEnergyHandler().resolve().get().getEnergyStored() & 0xffff;
+                    return controller.getEnergyHandler().resolve().
+                            map(iEnergyStorage -> iEnergyStorage.getEnergyStored() & 0xffff).
+                            orElse(0);
                 }
 
                 @Override
@@ -64,7 +66,9 @@ public class GyrofugeMenu extends AbstractBaseInventoryMenu {
             addDataSlot(new DataSlot() {
                 @Override
                 public int get() {
-                    return (controller.getEnergyHandler().resolve().get().getEnergyStored() >> 16) & 0xffff;
+                    return controller.getEnergyHandler().resolve().
+                            map(iEnergyStorage -> (iEnergyStorage.getEnergyStored() >> 16) & 0xffff).
+                            orElse(0);
                 }
 
                 @Override
@@ -75,7 +79,9 @@ public class GyrofugeMenu extends AbstractBaseInventoryMenu {
             addDataSlot(new DataSlot() {
                 @Override
                 public int get() {
-                    return controller.getEnergyHandler().resolve().get().getMaxEnergyStored() & 0xffff;
+                    return controller.getEnergyHandler().resolve().
+                            map(iEnergyStorage -> iEnergyStorage.getMaxEnergyStored() & 0xffff).
+                            orElse(0);
                 }
 
                 @Override
@@ -86,7 +92,9 @@ public class GyrofugeMenu extends AbstractBaseInventoryMenu {
             addDataSlot(new DataSlot() {
                 @Override
                 public int get() {
-                    return (controller.getEnergyHandler().resolve().get().getMaxEnergyStored() >> 16) & 0xffff;
+                    return controller.getEnergyHandler().resolve().
+                            map(iEnergyStorage -> (iEnergyStorage.getMaxEnergyStored() >> 16) & 0xffff).
+                            orElse(0);
                 }
 
                 @Override


### PR DESCRIPTION
When a player breaks the Gyrofuge while another player has its menu open, the server crashes with a NoSuchElementException. This PR fixes that.

https://mclo.gs/UU8kSMh