### PR TITLE
fix(multiblock): close Multiblock menu if it is no longer valid

### DIFF
--- a/src/main/java/com/accbdd/complicated_bees/block/AbstractGyrofugeBlock.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/AbstractGyrofugeBlock.java
@@ -75,7 +75,9 @@ public abstract class AbstractGyrofugeBlock extends BaseEntityBlock {
 
                     @Override
                     public AbstractContainerMenu createMenu(int windowId, Inventory playerInventory, Player player) {
-                        return new GyrofugeMenu(windowId, player, pPos, gyrofuge.getLogic().getController().getData());
+                        return gyrofuge.getLogic().getController().
+                                map(gyrofugeControllerBlockEntity -> new GyrofugeMenu(windowId, player, pPos, gyrofugeControllerBlockEntity.getData())).
+                                orElseGet(() -> new GyrofugeMenu(windowId, player, pPos));
                     }
                 };
 

--- a/src/main/java/com/accbdd/complicated_bees/block/AbstractMellariumBlock.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/AbstractMellariumBlock.java
@@ -75,7 +75,9 @@ public abstract class AbstractMellariumBlock extends BaseEntityBlock {
 
                     @Override
                     public AbstractContainerMenu createMenu(int windowId, Inventory playerInventory, Player player) {
-                        return new MellariumMenu(windowId, player, pPos, mellarium.getLogic().getController().getData());
+                        return mellarium.getLogic().getController().map(controller ->
+                                new MellariumMenu(windowId, player, pPos, controller.getData())
+                        ).orElseGet(() -> new MellariumMenu(windowId, player, pPos));
                     }
                 };
 

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/AbstractGyrofugeBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/AbstractGyrofugeBlockEntity.java
@@ -15,6 +15,8 @@ import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 public abstract class AbstractGyrofugeBlockEntity extends BlockEntity {
     private GyrofugeLogic logic;
     private BlockPos center;
@@ -45,11 +47,17 @@ public abstract class AbstractGyrofugeBlockEntity extends BlockEntity {
 
     @Override
     public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
-        if (getLogic() == null || getLogic().getController() == null)
+        GyrofugeLogic logic = getLogic();
+        if (logic == null) {
             return super.getCapability(cap, side);
+        }
+        Optional<GyrofugeControllerBlockEntity> controller = logic.getController();
+        if (controller.isEmpty()) {
+            return super.getCapability(cap, side);
+        }
 
         if (cap == ForgeCapabilities.ITEM_HANDLER) {
-            return getLogic().getController().getItemHandler().cast();
+            return controller.map(GyrofugeControllerBlockEntity::getItemHandler).orElse(LazyOptional.empty()).cast();
         }
 
         return super.getCapability(cap, side);

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/AbstractPoweredGyrofugeBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/AbstractPoweredGyrofugeBlockEntity.java
@@ -19,7 +19,7 @@ public abstract class AbstractPoweredGyrofugeBlockEntity extends AbstractGyrofug
 
     @Override
     public void onTick() {
-        if (getLogic() != null && getLogic().getController() != null) {
+        if (getLogic() != null && getLogic().getController().isPresent()) {
             setPowered(getLogic().getEnergyStorage().extractEnergy(getIdleUsage(), false) >= getIdleUsage());
         }
     }

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/GyrofugeControllerBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/GyrofugeControllerBlockEntity.java
@@ -89,7 +89,7 @@ public class GyrofugeControllerBlockEntity extends AbstractCentrifugeBlockEntity
 
     public GyrofugeLogic getGyrofugeLogic() {
         if (gyrofugeLogic == null && MultiblockHelper.isValidGyrofuge(getLevel(), getBlockPos())) {
-            MultiblockHelper.buildGyrofuge(getLevel(), getBlockPos());
+            setLogic(MultiblockHelper.buildGyrofuge(getLevel(), getBlockPos()));
         }
         return gyrofugeLogic;
     }
@@ -97,11 +97,14 @@ public class GyrofugeControllerBlockEntity extends AbstractCentrifugeBlockEntity
     @Override
     public void tickServer() {
         super.tickServer();
-        getGyrofugeLogic().getSpecialBlocks().stream().forEach(pos -> {
-            if (getLevel().getBlockEntity(pos) instanceof IGyrofugeTickable tickable) {
-                tickable.onTick();
-            }
-        });
+        GyrofugeLogic logic = getGyrofugeLogic();
+        if (logic != null) {
+            logic.getSpecialBlocks().forEach(pos -> {
+                if (level != null && level.getBlockEntity(pos) instanceof IGyrofugeTickable tickable) {
+                    tickable.onTick();
+                }
+            });
+        }
     }
 
     @Override

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/GyrofugeControllerBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/GyrofugeControllerBlockEntity.java
@@ -89,7 +89,7 @@ public class GyrofugeControllerBlockEntity extends AbstractCentrifugeBlockEntity
 
     public GyrofugeLogic getGyrofugeLogic() {
         if (gyrofugeLogic == null && MultiblockHelper.isValidGyrofuge(getLevel(), getBlockPos())) {
-            setLogic(MultiblockHelper.buildGyrofuge(getLevel(), getBlockPos()));
+            MultiblockHelper.buildGyrofuge(getLevel(), getBlockPos());
         }
         return gyrofugeLogic;
     }

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/GyrofugeInputHatchBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/GyrofugeInputHatchBlockEntity.java
@@ -23,14 +23,14 @@ public class GyrofugeInputHatchBlockEntity extends AbstractGyrofugeBlockEntity i
     public void setLogic(GyrofugeLogic logic) {
         super.setLogic(logic);
         if (logic != null)
-            this.gyrofugeInput = logic.getController().getInputItemHandler();
+            this.gyrofugeInput = logic.getController().map(GyrofugeControllerBlockEntity::getInputItemHandler).orElse(LazyOptional.empty());
         else
-            this.gyrofugeInput = null;
+            this.gyrofugeInput = LazyOptional.empty();
     }
 
     @Override
     public void onTick() {
-        if (gyrofugeInput != null && tickCount++ % 4 == 0) {
+        if (gyrofugeInput != null && gyrofugeInput.isPresent() && tickCount++ % 4 == 0) {
             for (Direction dir : Direction.values()) {
                 BlockEntity blockEntity = getLevel().getBlockEntity(getBlockPos().relative(dir));
                 if (blockEntity == null || blockEntity instanceof AbstractGyrofugeBlockEntity)

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/GyrofugeOutputHatchBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/gyrofuge/GyrofugeOutputHatchBlockEntity.java
@@ -23,14 +23,14 @@ public class GyrofugeOutputHatchBlockEntity extends AbstractGyrofugeBlockEntity 
     public void setLogic(GyrofugeLogic logic) {
         super.setLogic(logic);
         if (logic != null)
-            this.gyrofugeOutput = logic.getController().getOutputItemHandler();
+            this.gyrofugeOutput = logic.getController().map(GyrofugeControllerBlockEntity::getOutputItemHandler).orElse(LazyOptional.empty());
         else
-            this.gyrofugeOutput = null;
+            this.gyrofugeOutput = LazyOptional.empty();
     }
 
     @Override
     public void onTick() {
-        if (gyrofugeOutput != null && tickCount++ % 4 == 0) {
+        if (gyrofugeOutput != null && gyrofugeOutput.isPresent() && tickCount++ % 4 == 0) {
             for (Direction dir : Direction.values()) {
                 BlockEntity blockEntity = getLevel().getBlockEntity(getBlockPos().relative(dir));
                 if (blockEntity == null || blockEntity instanceof AbstractGyrofugeBlockEntity)

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/mellarium/AbstractMellariumBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/mellarium/AbstractMellariumBlockEntity.java
@@ -15,6 +15,8 @@ import net.minecraftforge.common.util.LazyOptional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
+
 /**
  * All mellarium blocks should extend this class
  */
@@ -48,11 +50,17 @@ public abstract class AbstractMellariumBlockEntity extends BlockEntity {
 
     @Override
     public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
-        if (getLogic() == null || getLogic().getController() == null)
+        MellariumLogic logic = getLogic();
+        if (logic == null) {
             return super.getCapability(cap, side);
+        }
+        Optional<MellariumControllerBlockEntity> controller = logic.getController();
+        if (controller.isEmpty()) {
+            return super.getCapability(cap, side);
+        }
 
         if (cap == ForgeCapabilities.ITEM_HANDLER) {
-            return getLogic().getController().getItemHandler().cast();
+            return controller.map(MellariumControllerBlockEntity::getItemHandler).orElse(LazyOptional.empty()).cast();
         }
 
         return super.getCapability(cap, side);

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/mellarium/MellariumHydroregulatorBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/mellarium/MellariumHydroregulatorBlockEntity.java
@@ -116,14 +116,16 @@ public class MellariumHydroregulatorBlockEntity extends AbstractMellariumBlockEn
     public void onBeeTick() {
         ItemStack stack = inputItems.getStackInSlot(0);
         quickCheck.getRecipeFor(new SimpleContainer(stack), getLevel()).ifPresent(recipe -> {
-            if (level.getRandom().nextFloat() < recipe.getUseChance()) {
-                stack.shrink(1);
-                if (stack.isEmpty()) {
-                    getLogic().getController().getLogic().clearConditionCache();
-                    getLogic().getController().getLogic().checkConditions();
+            getLogic().getController().ifPresent(controller -> {
+                if (level.getRandom().nextFloat() < recipe.getUseChance()) {
+                    stack.shrink(1);
+                    if (stack.isEmpty()) {
+                        controller.getLogic().clearConditionCache();
+                        controller.getLogic().checkConditions();
+                    }
+                    outputItems.insertItem(0, recipe.getOutput().getStackResult(), false);
                 }
-                outputItems.insertItem(0, recipe.getOutput().getStackResult(), false);
-            }
+            });
         });
     }
 

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/mellarium/MellariumOutputHatchBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/mellarium/MellariumOutputHatchBlockEntity.java
@@ -27,21 +27,11 @@ public class MellariumOutputHatchBlockEntity extends AbstractMellariumBlockEntit
     public void setLogic(MellariumLogic logic) {
         super.setLogic(logic);
         if (logic != null)
-            this.mellariumOutput = logic.getController().getOutputItemHandler();
+            logic.getController().ifPresent(controller ->
+                this.mellariumOutput = controller.getOutputItemHandler()
+            );
         else
-            this.mellariumOutput = null;
-    }
-
-    @Override
-    public @NotNull <T> LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
-        if (getLogic() == null || getLogic().getController() == null)
-            return super.getCapability(cap, side);
-
-        if (cap == ForgeCapabilities.ITEM_HANDLER) {
-            return getLogic().getController().getItemHandler().cast();
-        }
-
-        return super.getCapability(cap, side);
+            this.mellariumOutput = LazyOptional.empty();
     }
 
     @Override

--- a/src/main/java/com/accbdd/complicated_bees/block/entity/mellarium/MellariumTempUnitBlockEntity.java
+++ b/src/main/java/com/accbdd/complicated_bees/block/entity/mellarium/MellariumTempUnitBlockEntity.java
@@ -91,17 +91,19 @@ public class MellariumTempUnitBlockEntity extends AbstractMellariumBlockEntity i
         ItemStack stack = items.getStackInSlot(0);
         if (hasRecipe(stack)) {
             if (level.getRandom().nextFloat() < quickCheck.getRecipeFor(new SimpleContainer(stack), getLevel()).get().getUseChance()) {
-                if (stack.hasCraftingRemainingItem()) {
-                    items.setStackInSlot(0, stack.getCraftingRemainingItem());
-                    getLogic().getController().getLogic().clearConditionCache();
-                    getLogic().getController().getLogic().checkConditions();
-                } else {
-                    stack.shrink(1);
-                    if (stack.isEmpty()) {
-                        getLogic().getController().getLogic().clearConditionCache();
-                        getLogic().getController().getLogic().checkConditions();
+                getLogic().getController().ifPresent(controller -> {
+                    if (stack.hasCraftingRemainingItem()) {
+                        items.setStackInSlot(0, stack.getCraftingRemainingItem());
+                        controller.getLogic().clearConditionCache();
+                        controller.getLogic().checkConditions();
+                    } else {
+                        stack.shrink(1);
+                        if (stack.isEmpty()) {
+                            controller.getLogic().clearConditionCache();
+                            controller.getLogic().checkConditions();
+                        }
                     }
-                }
+                });
             }
         }
     }

--- a/src/main/java/com/accbdd/complicated_bees/multiblock/GyrofugeLogic.java
+++ b/src/main/java/com/accbdd/complicated_bees/multiblock/GyrofugeLogic.java
@@ -16,6 +16,7 @@ import net.minecraftforge.items.IItemHandler;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class GyrofugeLogic {
     private final Level level;
@@ -57,15 +58,15 @@ public class GyrofugeLogic {
 
     public void deconstruct(BlockPos pos) {
         BlockPosBoxIterator iterator = new BlockPosBoxIterator(center, 1, 1);
-        if (getController() != null) {
-            while (getController() != null && !getController().outputBuffer.empty()) {
-                Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), getController().outputBuffer.pop());
+        getController().ifPresent(controller -> {
+            while (!controller.outputBuffer.empty()) {
+                Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), controller.outputBuffer.pop());
             }
-            IItemHandler handler = getController().getItemHandler().orElseThrow(() -> new RuntimeException("no item handler found!"));
+            IItemHandler handler = controller.getItemHandler().orElseThrow(() -> new RuntimeException("no item handler found!"));
             for (int i = 0; i < handler.getSlots(); i++) {
                 Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), handler.getStackInSlot(i));
             }
-        }
+        });
         while (iterator.hasNext()) {
             BlockPos p = iterator.next();
             if (level.getBlockEntity(p) instanceof AbstractGyrofugeBlockEntity gyrofugeBlock) {
@@ -79,10 +80,10 @@ public class GyrofugeLogic {
         return center;
     }
 
-    public GyrofugeControllerBlockEntity getController() {
+    public Optional<GyrofugeControllerBlockEntity> getController() {
         if (level.getBlockEntity(center) instanceof GyrofugeControllerBlockEntity controller)
-            return controller;
-        return null;
+            return Optional.of(controller);
+        return Optional.empty();
     }
 
     public List<BlockPos> getSpecialBlocks() {

--- a/src/main/java/com/accbdd/complicated_bees/multiblock/MellariumLogic.java
+++ b/src/main/java/com/accbdd/complicated_bees/multiblock/MellariumLogic.java
@@ -17,9 +17,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.items.IItemHandler;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 public class MellariumLogic {
     private final Level level;
@@ -57,17 +55,17 @@ public class MellariumLogic {
 
     public void deconstruct(BlockPos pos) {
         BlockPosBoxIterator iterator = new BlockPosBoxIterator(center, 1, 1);
-        if (getController() != null) {
-            while (getController() != null && !getController().getOutputBuffer().empty()) {
-                ItemStack stack = getController().getOutputBuffer().pop();
+        getController().ifPresent(controller -> {
+            while (!controller.getOutputBuffer().empty()) {
+                ItemStack stack = controller.getOutputBuffer().pop();
                 if (stack.is(ItemTagGenerator.BEE))
                     Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), stack);
             }
-            IItemHandler handler = getController().getItemHandler().orElseThrow(() -> new RuntimeException("no item handler found!"));
+            IItemHandler handler = controller.getItemHandler().orElseThrow(() -> new RuntimeException("no item handler found!"));
             for (int i = 0; i < handler.getSlots(); i++) {
                 Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), handler.getStackInSlot(i));
             }
-        }
+        });
         while (iterator.hasNext()) {
             BlockPos p = iterator.next();
             if (level.getBlockEntity(p) instanceof AbstractMellariumBlockEntity mellariumBlock) {
@@ -89,10 +87,10 @@ public class MellariumLogic {
         return center;
     }
 
-    public MellariumControllerBlockEntity getController() {
+    public Optional<MellariumControllerBlockEntity> getController() {
         if (level.getBlockEntity(center) instanceof MellariumControllerBlockEntity controller)
-            return controller;
-        return null;
+            return Optional.of(controller);
+        return Optional.empty();
     }
 
     public List<BlockPos> getSpecialBlocks() {

--- a/src/main/java/com/accbdd/complicated_bees/screen/GyrofugeMenu.java
+++ b/src/main/java/com/accbdd/complicated_bees/screen/GyrofugeMenu.java
@@ -6,6 +6,7 @@ import com.accbdd.complicated_bees.block.entity.gyrofuge.GyrofugeControllerBlock
 import com.accbdd.complicated_bees.multiblock.GyrofugeLogic;
 import com.accbdd.complicated_bees.registry.MenuRegistration;
 import com.accbdd.complicated_bees.util.MultiblockHelper;
+import com.accbdd.complicated_bees.util.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ContainerData;
@@ -135,7 +136,7 @@ public class GyrofugeMenu extends AbstractBaseInventoryMenu {
 
     @Override
     public boolean stillValid(Player player) {
-            return logic != null && logic.getController().filter(controller -> MultiblockHelper.isValidGyrofuge(controller.getLevel(), logic.getCenter()) &&
-                    player.distanceToSqr((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D) <= 64.0D).isPresent();
+            return logic != null && logic.getController().
+                    filter(controller -> MultiblockHelper.isValidGyrofuge(controller.getLevel(), logic.getCenter()) && Util.canReach(pos, player)).isPresent();
     }
 }

--- a/src/main/java/com/accbdd/complicated_bees/screen/GyrofugeMenu.java
+++ b/src/main/java/com/accbdd/complicated_bees/screen/GyrofugeMenu.java
@@ -3,16 +3,17 @@ package com.accbdd.complicated_bees.screen;
 import com.accbdd.complicated_bees.bees.MachineModifier;
 import com.accbdd.complicated_bees.block.entity.gyrofuge.AbstractGyrofugeBlockEntity;
 import com.accbdd.complicated_bees.block.entity.gyrofuge.GyrofugeControllerBlockEntity;
+import com.accbdd.complicated_bees.multiblock.GyrofugeLogic;
 import com.accbdd.complicated_bees.registry.MenuRegistration;
 import com.accbdd.complicated_bees.util.MultiblockHelper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ContainerData;
-import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.DataSlot;
 import net.minecraft.world.inventory.SimpleContainerData;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.items.SlotItemHandler;
+
+import java.util.Optional;
 
 public class GyrofugeMenu extends AbstractBaseInventoryMenu {
     private final BlockPos pos;
@@ -23,6 +24,7 @@ public class GyrofugeMenu extends AbstractBaseInventoryMenu {
     private int power;
     private int maxPower;
     protected MachineModifier modifier;
+    private GyrofugeLogic logic;
 
     public GyrofugeMenu(int windowId, Player player, BlockPos pos) {
         this(windowId, player, pos, new SimpleContainerData(3));
@@ -33,13 +35,16 @@ public class GyrofugeMenu extends AbstractBaseInventoryMenu {
         this.data = data;
         this.pos = pos;
         if (player.level().getBlockEntity(pos) instanceof AbstractGyrofugeBlockEntity blockEntity) {
-            GyrofugeControllerBlockEntity controller;
             if (blockEntity.getLogic() != null) {
-                controller = blockEntity.getLogic().getController();
+                logic = blockEntity.getLogic();
             } else {
-                controller = MultiblockHelper.tryBuildGyrofuge(player.level(), pos).getController();
+                logic = MultiblockHelper.tryBuildGyrofuge(player.level(), pos);
             }
-            modifier = controller.getGyrofugeLogic().getMachineModifier();
+            if (logic == null) return;
+            Optional<GyrofugeControllerBlockEntity> controllerOptional = logic.getController();
+            if (controllerOptional.isEmpty()) return;
+            modifier = logic.getMachineModifier();
+            GyrofugeControllerBlockEntity controller = controllerOptional.get();
             addSlot(new SlotItemHandler(controller.getInputItems(), 0, 15, 26));
             addSlot(new SlotItemHandler(controller.getInputItems(), 1, 33, 26));
             addSlot(new SlotItemHandler(controller.getInputItems(), 2, 15, 44));
@@ -130,6 +135,7 @@ public class GyrofugeMenu extends AbstractBaseInventoryMenu {
 
     @Override
     public boolean stillValid(Player player) {
-        return ContainerLevelAccess.create(player.level(), pos).evaluate((level, pos1) -> !level.getBlockState(pos1).is(Blocks.AIR)).get() && player.distanceToSqr((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D) <= 64.0D;
+            return logic != null && logic.getController().filter(controller -> MultiblockHelper.isValidGyrofuge(controller.getLevel(), logic.getCenter()) &&
+                    player.distanceToSqr((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D) <= 64.0D).isPresent();
     }
 }

--- a/src/main/java/com/accbdd/complicated_bees/screen/MellariumMenu.java
+++ b/src/main/java/com/accbdd/complicated_bees/screen/MellariumMenu.java
@@ -3,21 +3,23 @@ package com.accbdd.complicated_bees.screen;
 import com.accbdd.complicated_bees.block.entity.mellarium.AbstractMellariumBlockEntity;
 import com.accbdd.complicated_bees.block.entity.mellarium.MellariumControllerBlockEntity;
 import com.accbdd.complicated_bees.datagen.ItemTagGenerator;
+import com.accbdd.complicated_bees.multiblock.MellariumLogic;
 import com.accbdd.complicated_bees.registry.ItemsRegistration;
 import com.accbdd.complicated_bees.registry.MenuRegistration;
 import com.accbdd.complicated_bees.screen.slot.ItemSlot;
 import com.accbdd.complicated_bees.screen.slot.OutputSlot;
 import com.accbdd.complicated_bees.screen.slot.TagSlot;
 import com.accbdd.complicated_bees.util.MultiblockHelper;
+import com.accbdd.complicated_bees.util.Util;
 import com.accbdd.complicated_bees.util.enums.EnumErrorCodes;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ContainerData;
-import net.minecraft.world.inventory.ContainerLevelAccess;
 import net.minecraft.world.inventory.DataSlot;
 import net.minecraft.world.inventory.SimpleContainerData;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.Blocks;
+
+import java.util.Optional;
 
 import static com.accbdd.complicated_bees.block.entity.mellarium.MellariumControllerBlockEntity.*;
 
@@ -29,6 +31,7 @@ public class MellariumMenu extends AbstractBaseInventoryMenu {
 
     private int power;
     private int maxPower;
+    private MellariumLogic logic;
 
     public MellariumMenu(int windowId, Player player, BlockPos pos) {
         this(windowId, player, pos, new SimpleContainerData(3));
@@ -41,10 +44,14 @@ public class MellariumMenu extends AbstractBaseInventoryMenu {
         if (player.level().getBlockEntity(pos) instanceof AbstractMellariumBlockEntity blockEntity) {
             MellariumControllerBlockEntity controller;
             if (blockEntity.getLogic() != null) {
-                controller = blockEntity.getLogic().getController();
+                logic = blockEntity.getLogic();
             } else {
-                controller = MultiblockHelper.tryBuildMellarium(player.level(), pos, player.getUUID()).getController();
+                logic = MultiblockHelper.tryBuildMellarium(player.level(), pos, player.getUUID());
             }
+            if (logic == null) return;
+            Optional<MellariumControllerBlockEntity> controllerOptional = logic.getController();
+            if (controllerOptional.isEmpty()) return;
+            controller = controllerOptional.get();
             addSlot(new TagSlot(controller.getBeeItems(), BEE_SLOT, 29, 38, ItemTagGenerator.ROYAL));
             addSlot(new ItemSlot(controller.getBeeItems(), BEE_SLOT + 1, 29, 63, ItemsRegistration.DRONE.get()));
 
@@ -108,7 +115,9 @@ public class MellariumMenu extends AbstractBaseInventoryMenu {
 
     @Override
     public boolean stillValid(Player player) {
-        return ContainerLevelAccess.create(player.level(), pos).evaluate((level, pos1) -> !level.getBlockState(pos1).is(Blocks.AIR)).get() && player.distanceToSqr((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D) <= 64.0D;
+        return logic != null && logic.getController().
+                filter(controller -> MultiblockHelper.isValidMellarium(player.level(), logic.getCenter()) && Util.canReach(pos, player)).
+                isPresent();
     }
 
     public boolean hasQueen() {

--- a/src/main/java/com/accbdd/complicated_bees/util/MultiblockHelper.java
+++ b/src/main/java/com/accbdd/complicated_bees/util/MultiblockHelper.java
@@ -78,8 +78,8 @@ public class MultiblockHelper {
         while (structureIterator.hasNext()) {
             BlockPos structurePos = structureIterator.next();
             if (level.getBlockEntity(structurePos) instanceof AbstractGyrofugeBlockEntity gyrofugeBlock) {
-                if (gyrofugeBlock.getLogic() != null && !level.isClientSide()) {
-                    //todo: dear god, fix this garbage !isClientSide call
+                GyrofugeLogic logic = gyrofugeBlock.getLogic();
+                if (logic != null && logic.getController().isPresent() && !logic.getCenter().equals(center)) {
                     return false;
                 } else {
                     if (!(gyrofugeBlock instanceof GyrofugeBaseBlockEntity) && structurePos.getY() > center.getY()) //only allow non-base blocks in the bottom two layers

--- a/src/main/java/com/accbdd/complicated_bees/util/MultiblockHelper.java
+++ b/src/main/java/com/accbdd/complicated_bees/util/MultiblockHelper.java
@@ -37,8 +37,8 @@ public class MultiblockHelper {
         while (structureIterator.hasNext()) {
             BlockPos structurePos = structureIterator.next();
             if (level.getBlockEntity(structurePos) instanceof AbstractMellariumBlockEntity mellariumBlock) {
-                if (mellariumBlock.getLogic() != null && !level.isClientSide()) {
-                    //todo: dear god, fix this garbage !isClientSide call
+                MellariumLogic logic = mellariumBlock.getLogic();
+                if (logic != null && logic.getController().isPresent() && !logic.getCenter().equals(center)) {
                     return false;
                 } else {
                     if (!(mellariumBlock instanceof MellariumBaseBlockEntity) && structurePos.getY() > center.getY()) //only allow non-base blocks in the bottom two layers

--- a/src/main/java/com/accbdd/complicated_bees/util/Util.java
+++ b/src/main/java/com/accbdd/complicated_bees/util/Util.java
@@ -4,6 +4,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.levelgen.Heightmap;
@@ -91,5 +92,20 @@ public class Util {
             }
         }
         return stack;
+    }
+
+    /**
+     * Checks whether the target block is within the player's interaction reach.
+     *
+     * @param pos position of the target block
+     * @param player the target player
+     * @return whether the target block is within the player's reach
+     */
+    public static boolean canReach(BlockPos pos, Player player) {
+        return player.distanceToSqr(
+                pos.getX() + 0.5D,
+                pos.getY() + 0.5D,
+                pos.getZ() + 0.5D
+        ) <= 64.0D;
     }
 }


### PR DESCRIPTION
In some cases, the Multiblock menu remains open if the Multiblock becomes invalid while the menu is open. This PR fixes the issue. Also fixes several potential NPEs.